### PR TITLE
improve translation

### DIFF
--- a/xml/System.Threading/AutoResetEvent.xml
+++ b/xml/System.Threading/AutoResetEvent.xml
@@ -65,7 +65,7 @@
    
   
 ## Examples  
- 下列範例示範如何使用<xref:System.Threading.AutoResetEvent>呼叫一次釋放一個執行緒<xref:System.Threading.EventWaitHandle.Set%2A>方法 （在基底類別中） 每次使用者按下**Enter**索引鍵。 此範例會啟動三個執行緒，等候以收到信號狀態建立的<xref:System.Threading.AutoResetEvent>。 第一個執行緒被立即釋放，因為<xref:System.Threading.AutoResetEvent>已經處於收到信號的狀態。 這會重設<xref:System.Threading.AutoResetEvent>未收到信號的狀態，以便後續的執行緒封鎖。 已封鎖的執行緒不會釋放直到使用者放開它們一一次按下**Enter**索引鍵。  
+ 下列範例示範如何使用 <xref:System.Threading.AutoResetEvent> 一次釋放一個執行緒，方式是透過每次使用者按下 **Enter** 鍵時呼叫 <xref:System.Threading.EventWaitHandle.Set%2A> 方法 (在基底類別中)。此範例會啟動三個執行緒，等候在已收到信號狀態中建立的 <xref:System.Threading.AutoResetEvent>。第一個執行緒會被立即釋放，因為 <xref:System.Threading.AutoResetEvent> 已處於收到信號的狀態。這會將 <xref:System.Threading.AutoResetEvent> 重設為未收到信號的狀態，以便封鎖後續的執行緒。已封鎖的執行緒不會被釋放，直到使用者一次按 **Enter** 鍵釋放一個。
   
  執行緒會從第一個釋放之後<xref:System.Threading.AutoResetEvent>，在等候另一個<xref:System.Threading.AutoResetEvent>中未收到信號的狀態建立。 所有的三個執行緒封鎖，因此<xref:System.Threading.EventWaitHandle.Set%2A>方法必須發行所有的這些呼叫三次。  
   

--- a/xml/System.Threading/AutoResetEvent.xml
+++ b/xml/System.Threading/AutoResetEvent.xml
@@ -65,7 +65,7 @@
    
   
 ## Examples  
- 下列範例示範如何使用<xref:System.Threading.AutoResetEvent>呼叫一次釋放一個執行緒<xref:System.Threading.EventWaitHandle.Set%2A>方法 （在基底類別中） 每次使用者按下**Enter**索引鍵。 此範例會啟動三個執行緒，等候<xref:System.Threading.AutoResetEvent>收到信號的狀態中建立。 第一次釋放執行緒後立即執行，因為<xref:System.Threading.AutoResetEvent>已經處於收到信號的狀態。 這會重設<xref:System.Threading.AutoResetEvent>未收到信號的狀態，以便後續的執行緒封鎖。 已封鎖的執行緒不會釋放直到使用者放開它們一一次按下**Enter**索引鍵。  
+ 下列範例示範如何使用<xref:System.Threading.AutoResetEvent>呼叫一次釋放一個執行緒<xref:System.Threading.EventWaitHandle.Set%2A>方法 （在基底類別中） 每次使用者按下**Enter**索引鍵。 此範例會啟動三個執行緒，等候以收到信號狀態建立的<xref:System.Threading.AutoResetEvent>。 第一個執行緒被立即釋放，因為<xref:System.Threading.AutoResetEvent>已經處於收到信號的狀態。 這會重設<xref:System.Threading.AutoResetEvent>未收到信號的狀態，以便後續的執行緒封鎖。 已封鎖的執行緒不會釋放直到使用者放開它們一一次按下**Enter**索引鍵。  
   
  執行緒會從第一個釋放之後<xref:System.Threading.AutoResetEvent>，在等候另一個<xref:System.Threading.AutoResetEvent>中未收到信號的狀態建立。 所有的三個執行緒封鎖，因此<xref:System.Threading.EventWaitHandle.Set%2A>方法必須發行所有的這些呼叫三次。  
   


### PR DESCRIPTION
* English: `which wait on an AutoResetEvent that was created in the signaled state.`  Chinese from `等候AutoResetEvent收到信號的狀態中建立。` improve as `等候以收到信號狀態建立的AutoResetEvent`

* English: `The first thread is released immediately` Chinese from `第一次釋放執行緒後立即執行` improve as `第一個執行緒被立即釋放`