### PR TITLE
Correct description in <Examples> section.

### DIFF
--- a/xml/System/StringComparison.xml
+++ b/xml/System/StringComparison.xml
@@ -56,7 +56,7 @@
  如需有關比較的詳細資訊，請參閱<xref:System.String?displayProperty=nameWithType>類別 < 備註 >。 如需文化特性的詳細資訊，請參閱<xref:System.Globalization.CultureInfo?displayProperty=nameWithType>類別 < 備註 >。 如需關於何時應該使用序數或區分文化特性的比較規則或規則的文化特性而異的指導方針，請參閱[使用字串的最佳做法](~/docs/standard/base-types/best-practices-strings.md)。 一組文字檔案包含在 Windows 作業系統的排序和比較作業中使用的字元加權的詳細資訊，請參閱 <<c0> [ 排序權數資料表](https://www.microsoft.com/download/details.aspx?id=10921)。 適用於 Linux 和 macOS 排序權數資料表，請參閱[Unicode 定序項目資料表](https://www.unicode.org/Public/UCA/latest/allkeys.txt)。   
   
 ## Examples  
- 下列範例將使用<xref:System.StringComparison>列舉型別的每個成員來比較四組單字。 比較時使用了英語 （美國） 和北方薩米語 （瑞典） 文化特性的慣例，您會發現，字串"encyclopædia"和"encyclopedia"在 en-US 文化特性下會被視為相等，但在北方薩米語 （瑞典） 文化特性下則不然。  
+ 下列範例將使用 <xref:System.StringComparison> 列舉型別的每個成員來比較四組單字。比較時使用了英文 (美國) 和北薩米文 (瑞典) 文化特性的慣例。請注意，字串 "encyclopædia" 和 "encyclopedia" 在 en-US 文化特性下會被視為相等，但在北薩米文 (瑞典) 文化特性下則不然。
   
  [!code-csharp[System.String.Equals#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.string.equals/cs/equals_ex3.cs#3)]
  [!code-vb[System.String.Equals#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.string.equals/vb/equals_ex3.vb#3)]  

--- a/xml/System/StringComparison.xml
+++ b/xml/System/StringComparison.xml
@@ -56,7 +56,7 @@
  如需有關比較的詳細資訊，請參閱<xref:System.String?displayProperty=nameWithType>類別 < 備註 >。 如需文化特性的詳細資訊，請參閱<xref:System.Globalization.CultureInfo?displayProperty=nameWithType>類別 < 備註 >。 如需關於何時應該使用序數或區分文化特性的比較規則或規則的文化特性而異的指導方針，請參閱[使用字串的最佳做法](~/docs/standard/base-types/best-practices-strings.md)。 一組文字檔案包含在 Windows 作業系統的排序和比較作業中使用的字元加權的詳細資訊，請參閱 <<c0> [ 排序權數資料表](https://www.microsoft.com/download/details.aspx?id=10921)。 適用於 Linux 和 macOS 排序權數資料表，請參閱[Unicode 定序項目資料表](https://www.unicode.org/Public/UCA/latest/allkeys.txt)。   
   
 ## Examples  
- 下列範例會比較四字組所使用的每個成員<xref:System.StringComparison>列舉型別。  比較使用英文 （美國） 和沙米文 （瑞典） Nothern 文化特性的慣例。 請注意，字串"encyclopædia"和"百科全書"會被視為對等項目以 EN-US 文化特性，但不是在沙米文，北馬 （瑞典） 文化特性。  
+ 下列範例將使用<xref:System.StringComparison>列舉型別的每個成員來比較四組單字。 比較時使用了英語 （美國） 和北方薩米語 （瑞典） 文化特性的慣例，您會發現，字串"encyclopædia"和"encyclopedia"在 en-US 文化特性下會被視為相等，但在北方薩米語 （瑞典） 文化特性下則不然。  
   
  [!code-csharp[System.String.Equals#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.string.equals/cs/equals_ex3.cs#3)]
  [!code-vb[System.String.Equals#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.string.equals/vb/equals_ex3.vb#3)]  


### PR DESCRIPTION
1. Incorrect grammatical and lexical order
2. Incorrect translation of name of Northern Sami language
3. Unnecessary translation of word for example